### PR TITLE
fix wrong doublequotes in Dockerfile

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -19,7 +19,7 @@ RUN yum --setopt=tsflags=nodocs -y install wget nfs-utils attr iputils iproute
 
 RUN wget http://download.gluster.org/pub/gluster/glusterfs/3.7/LATEST/EPEL.repo/glusterfs-epel.repo -O /etc/yum.repos.d/glusterfs-epel.repo
 
-RUN wget http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm; rpm -ivh epel-release-7-6.noarch.rpm; rm epel-release-7-6.noarch.rpm;
+RUN wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm; rpm -ivh epel-release-latest-7.noarch.rpm; rm epel-release-latest-7.noarch.rpm;
 
 RUN yum --setopt=tsflags=nodocs -y install glusterfs glusterfs-server glusterfs-geo-replication openssh-server
 

--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -19,7 +19,7 @@ RUN yum --setopt=tsflags=nodocs -y install wget nfs-utils attr iputils iproute
 
 RUN wget http://download.gluster.org/pub/gluster/glusterfs/3.7/LATEST/EPEL.repo/glusterfs-epel.repo -O /etc/yum.repos.d/glusterfs-epel.repo
 
-RUN wget http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm; rpm -ivh epel-release-7-5.noarch.rpm; rm epel-release-7-5.noarch.rpm;
+RUN wget http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm; rpm -ivh epel-release-7-6.noarch.rpm; rm epel-release-7-6.noarch.rpm;
 
 RUN yum --setopt=tsflags=nodocs -y install glusterfs glusterfs-server glusterfs-geo-replication openssh-server
 

--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -26,7 +26,7 @@ RUN yum --setopt=tsflags=nodocs -y install glusterfs glusterfs-server glusterfs-
 RUN yum clean all
 
 RUN echo 'root:password' | chpasswd
-VOLUME [ “/sys/fs/cgroup” ]
+VOLUME [ "/sys/fs/cgroup" ]
 
 EXPOSE 22 111 245 443 24007 2049 8080 6010 6011 6012 38465 38466 38468 38469 49152 49153 49154 49156 49157 49158 49159 49160 49161 49162 49163
 

--- a/Fedora/Dockerfile
+++ b/Fedora/Dockerfile
@@ -19,7 +19,7 @@ rm -f /lib/systemd/system/anaconda.target.wants/*;
 RUN yum --setopt=tsflags=nodocs -y install wget nfs-utils iputils iproute attr glusterfs glusterfs-server glusterfs-geo-replication openssh-server; yum clean all
 
 RUN echo 'root:password' | chpasswd
-VOLUME [ “/sys/fs/cgroup” ]
+VOLUME [ "/sys/fs/cgroup" ]
 
 EXPOSE 22 111 245 443 24007 2049 8080 6010 6011 6012 38465 38466 38468 38469 49152 49153 49154 49156 49157 49158 49159 49160 49161 49162 49163
 


### PR DESCRIPTION
Wrong doublequotes in Dockerfile (unicode U+201C) cause wrong parsing of Volumes and therefore strange mounts within the container.

```
# docker inspect gluster/gluster-centos
...
        "Volumes": {
            "[": {},
            "]": {},
            "“/sys/fs/cgroup”": {}
        },
...
```
