### PR TITLE
Centos Dockerfile upgrade

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM centos:7
 
 MAINTAINER Humble Chirammal hchiramm@redhat.com
 
@@ -19,19 +19,38 @@ RUN yum --setopt=tsflags=nodocs -y install wget nfs-utils attr iputils iproute
 
 RUN wget http://download.gluster.org/pub/gluster/glusterfs/3.7/LATEST/EPEL.repo/glusterfs-epel.repo -O /etc/yum.repos.d/glusterfs-epel.repo
 
-RUN wget http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm; rpm -ivh epel-release-7-5.noarch.rpm; rm epel-release-7-5.noarch.rpm;
+RUN wget http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm; rpm -ivh epel-release-7-6.noarch.rpm; rm epel-release-7-6.noarch.rpm;
 
-RUN yum --setopt=tsflags=nodocs -y install glusterfs glusterfs-server glusterfs-geo-replication openssh-server
+RUN yum --setopt=tsflags=nodocs -y install openssh-server openssh-clients ntp rsync tar cronie sudo xfsprogs glusterfs glusterfs-server glusterfs-geo-replication;yum clean all;
 
-RUN yum clean all
+RUN sed -i '/Defaults    requiretty/c\#Defaults    requiretty' /etc/sudoers
+
+# Changing the port of sshd to avoid conflicting with host sshd
+RUN sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config
+
+# Backing up gluster config as it overlaps when bind mounting.
+RUN mkdir -p /etc/glusterfs_bkp /var/lib/glusterd_bkp /var/log/glusterfs_bkp;\
+cp -r /etc/glusterfs/* /etc/glusterfs_bkp;\
+cp -r /var/lib/glusterd/* /var/lib/glusterd_bkp;\
+cp -r /var/log/glusterfs/* /var/log/glusterfs_bkp;
+
+# Adding script to move the glusterfs config file to location
+ADD gluster-setup.service /etc/systemd/system/gluster-setup.service
+RUN chmod 644 /etc/systemd/system/gluster-setup.service
+
+# Adding script to move the glusterfs config file to location
+ADD gluster-setup.sh /usr/sbin/gluster-setup.sh
+RUN chmod 500 /usr/sbin/gluster-setup.sh
 
 RUN echo 'root:password' | chpasswd
 VOLUME [ “/sys/fs/cgroup” ]
 
-EXPOSE 22 111 245 443 24007 2049 8080 6010 6011 6012 38465 38466 38468 38469 49152 49153 49154 49156 49157 49158 49159 49160 49161 49162
-
 RUN systemctl disable nfs-server.service
+RUN systemctl enable ntpd.service
 RUN systemctl enable rpcbind.service
 RUN systemctl enable glusterd.service
+RUN systemctl enable gluster-setup.service
+
+EXPOSE 2222 111 245 443 24007 2049 8080 6010 6011 6012 38465 38466 38468 38469 49152 49153 49154 49156 49157 49158 49159 49160 49161 49162
 
 CMD ["/usr/sbin/init"]

--- a/CentOS/gluster-setup.service
+++ b/CentOS/gluster-setup.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Configuring GlusterFS in container
+Before=rpcbind.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/setup.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/CentOS/gluster-setup.sh
+++ b/CentOS/gluster-setup.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+###
+# Description: Script to move the glusterfs initial setup to bind mounted directories of Atomic Host.
+# Copyright (c) 2016 Red Hat, Inc. <http://www.redhat.com>
+#
+# This file is part of GlusterFS.
+#
+# This file is licensed to you under your choice of the GNU Lesser
+# General Public License, version 3 or any later version (LGPLv3 or
+# later), or the GNU General Public License, version 2 (GPLv2), in all
+# cases as published by the Free Software Foundation.
+###
+
+main () {
+  if test "$(ls /var/lib/heketi/fstab)"
+  then
+        mount -a --fstab /var/lib/heketi/fstab
+        if [ $? -eq 1 ]
+        then
+              echo "mount failed"
+              exit 1
+        fi
+        echo "Mount Successful"
+  else
+        echo "heketi-fstab not found"
+  fi
+  DIR_1="/etc/glusterfs"
+  DIR_2="/var/log/glusterfs"
+  DIR_3="/var/lib/glusterd"
+  var=0
+  for i in $DIR_1 $DIR_2 $DIR_3
+  do
+    if test "$(ls $i)"
+    then
+      echo "$i is not empty"
+      var=$((var+1))
+    fi
+  done
+
+  if [ $var -eq 3 ]
+  then
+        exit 1
+  fi
+  
+  cp -r /etc/glusterfs_bkp/* /etc/glusterfs
+  if [ $? -eq 1 ]
+  then
+	echo "Failed to copy $DIR_1" 
+        exit 1
+  fi
+
+  cp -r /var/log/glusterfs_bkp/* /var/log/glusterfs
+  if [ $? -eq 1 ]
+  then
+	echo "Failed to copy $DIR_2"
+        exit 1
+  fi
+
+  cp -r /var/lib/glusterd_bkp/* /var/lib/glusterd
+  if [ $? -eq 1 ]
+  then
+	echo "Failed to copy $DIR_3"
+	exit 1
+  fi
+ 
+  echo "Script Ran Successfully"
+}
+main


### PR DESCRIPTION
Adding gluster-setup files which is used on first initialization
of gluster contianer as bind mount of gluster config directory will
be empty. This gluster-setup will copy the initial config files which
is required for glusterd to start.

Adding packages for gluster services to work,
ntp, rsync, tar, openssh-server, openssh-clients : Required for geo-replication
cronie : Required for snapshot-scheduler-script

Signed-off-by: Mohamed Ashiq Liyazudeen <mliyazud@redhat.com>