### PR TITLE
dont need EPEL, the deps should all resolve locally

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -17,8 +17,6 @@ rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN yum --setopt=tsflags=nodocs -y install wget nfs-utils attr iputils iproute centos-release-gluster
 
-RUN wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm; rpm -ivh epel-release-latest-7.noarch.rpm; rm epel-release-latest-7.noarch.rpm;
-
 RUN yum --setopt=tsflags=nodocs -y install openssh-server openssh-clients ntp rsync tar cronie sudo xfsprogs glusterfs glusterfs-server glusterfs-geo-replication;yum clean all;
 
 RUN sed -i '/Defaults    requiretty/c\#Defaults    requiretty' /etc/sudoers


### PR DESCRIPTION
There shouldnt be any need to include EPEL for the build, and in basic testing the container built without it deploys and works ok. I've only done some very basic testing, but seems ok.

Can we then lose the epel-release dependancy ?